### PR TITLE
Fix: Python 3.8 compatibility

### DIFF
--- a/merak/core/refactor/restructure.py
+++ b/merak/core/refactor/restructure.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import ast
 import collections
 import io
+import os
 import pathlib
 import re
 import shutil
@@ -298,9 +299,9 @@ class ModuleIndex(base.MerakBase):
     # mod: ("mod", "path", "in", "tuple") -> fullpath
     # data: {data fullpath}
     mod, data = {}, set()
-    for r, _, fs in self._root.walk():
+    for r, _, fs in os.walk(str(self._root)):
       for f in fs:
-        path = r.joinpath(f)
+        path = pathlib.Path(r).joinpath(f)
         if path.suffix in self._exts:
           mod[self.to_module(path)] = path
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "merak"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     {name = "(David) Siu-Kei Muk", email = "david.muk@proton.me"},
 ]
 license = {file = "LICENSE"}
 description = "Python binary package builder (via Cython)"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 keywords = ["merak", "cython", "binary", "package", "build"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -20,9 +20,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Cython",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This fix makes use of `os.walk` instead of `Path.walk` as the latter was introduced in 3.12, which causes compatibility issues

The earliest Python version to be supported by this tool will be updated to 3.8 as it's the earliest version that I'm able to install on my machine (Mac M2 Pro)